### PR TITLE
Encode device name in outbound URL paths to prevent path traversal

### DIFF
--- a/src/services/homeassistant.ts
+++ b/src/services/homeassistant.ts
@@ -40,14 +40,17 @@ export default async (request: FastifyRequest): Promise<void> => {
       `Sending data to homeassistant at ${url} for device ${deviceLabel} for state ${stateName} `,
     );
     try {
-      const response = await fetch(`${url}/api/states/sensor.${deviceLabel}_${stateName}`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
+      const response = await fetch(
+        `${url}/api/states/sensor.${encodeURIComponent(deviceLabel)}_${stateName}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify(payload),
         },
-        body: JSON.stringify(payload),
-      });
+      );
       const resData = await response.text();
       if (!response.ok) {
         throw new FetchError(response.status, resData);

--- a/src/services/ubidots.ts
+++ b/src/services/ubidots.ts
@@ -53,14 +53,17 @@ export default async (request: FastifyRequest): Promise<void> => {
 
       try {
         request.log.info(`Sending data to Ubidots for device ${name}`);
-        const response = await fetch(`https://things.ubidots.com/api/v1.6/devices/${name}`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": token,
+        const response = await fetch(
+          `https://things.ubidots.com/api/v1.6/devices/${encodeURIComponent(name)}`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "X-Auth-Token": token,
+            },
+            body: JSON.stringify(payload),
           },
-          body: JSON.stringify(payload),
-        });
+        );
         if (!response.ok) {
           const resData = await response.text();
           throw new FetchError(response.status, resData);

--- a/tests/services/homeassistant.test.ts
+++ b/tests/services/homeassistant.test.ts
@@ -179,6 +179,58 @@ test("homeassistant service", async (t) => {
     t.match(firstCall, /sensor\.iSpindel001_/, "uses iSpindel name when deviceLabel not provided");
   });
 
+  t.test("encodes device name to prevent path traversal", async (t) => {
+    const mockConfig = {
+      serverPath: "/test",
+      services: [
+        {
+          type: "homeassistant",
+          url: "http://homeassistant.local:8123",
+          token: "ha-token-123",
+        },
+      ],
+    };
+    getConfigStub.resolves(mockConfig);
+
+    // Malicious name attempting to escape /api/states/sensor.* and reach the
+    // privileged service-call endpoint via path traversal + fragment.
+    const ispindelData: IspindelData = {
+      name: "x/../../services/light/turn_on#",
+      ID: 12345,
+      token: "test-token",
+      angle: 45.5,
+      temperature: 68.2,
+      temp_units: "F",
+      battery: 3.8,
+      gravity: 1.05,
+      interval: 900,
+      RSSI: -65,
+    };
+
+    const mockRequest = {
+      body: ispindelData,
+      log: {
+        info: sinon.stub(),
+        error: sinon.stub(),
+      },
+    } as unknown as FastifyRequest;
+
+    await homeAssistantService(mockRequest);
+
+    fetchStub.getCalls().forEach((call) => {
+      const requestUrl = call.args[0];
+      // The traversal characters must be percent-encoded, not interpolated raw.
+      t.notMatch(requestUrl, /\.\.\//, "raw '../' traversal sequence not present in URL");
+      // After WHATWG URL normalization, the request must stay under /api/states/.
+      const { pathname } = new URL(requestUrl);
+      t.ok(
+        pathname.startsWith("/api/states/sensor."),
+        `request stays under /api/states/ (got ${pathname})`,
+      );
+      t.notMatch(pathname, /\/api\/services\//, "cannot reach the service-call endpoint");
+    });
+  });
+
   t.test("logs error when URL not configured", async (t) => {
     const mockConfig = {
       serverPath: "/test",
@@ -386,6 +438,10 @@ test("homeassistant service", async (t) => {
     t.notOk(fetchStub.called, "fetch not called when config fails");
     const errorStub = mockRequest.log.error as sinon.SinonStub;
     t.ok(errorStub.called, "error logged when config fails to load");
-    t.match(errorStub.firstCall.args[1], /Failed to load config/, "logs config load failure message");
+    t.match(
+      errorStub.firstCall.args[1],
+      /Failed to load config/,
+      "logs config load failure message",
+    );
   });
 });


### PR DESCRIPTION
The attacker-controlled iSpindel `name` field was interpolated unencoded into outbound service URL paths. Since Node's fetch normalizes `../` and strips `#` fragments, a request like `{ name: x/../../services/light/turn_on# }` escaped the intended `/api/states/sensor.*` route and reached privileged Home Assistant endpoints (e.g. /api/services/light/turn_on) while carrying the operator's long-lived Bearer token — an authenticated request-forgery allowing arbitrary HA service calls. The POST route is unauthenticated and the schema places no constraint on `name`.

Wrap the device label/name in encodeURIComponent() in the Home Assistant and Ubidots hooks. Encoding (vs. a schema allowlist) safely handles all legitimate device names, including spaces and special characters, while making traversal impossible.

Add a regression test asserting a traversal payload stays under /api/states/sensor. and cannot reach /api/services/.